### PR TITLE
Add Match object to the AddressParseResult

### DIFF
--- a/src/AddressParser/AddressParseResult.cs
+++ b/src/AddressParser/AddressParseResult.cs
@@ -33,10 +33,16 @@ namespace USAddress
         ///     Initializes a new instance of the <see cref="AddressParseResult" /> class.
         /// </summary>
         /// <param name="fields">The fields that were parsed.</param>
-        public AddressParseResult(Dictionary<string, string> fields)
+        public AddressParseResult(Dictionary<string, string> fields, Match regexMatch = null)
         {
             _fields = fields ?? new Dictionary<string, string>();
+            RegexMatch = regexMatch;
         }
+
+        /// <summary>
+        ///     Gets the source RegularExpressions.Match object holding positional information in input text.
+        /// </summary>
+        public Match RegexMatch { get; private set; }
 
         /// <summary>
         ///     Gets the city name.

--- a/src/AddressParser/AddressParser.cs
+++ b/src/AddressParser/AddressParser.cs
@@ -960,7 +960,7 @@ namespace USAddress
                 extracted = Normalize(extracted);
             }
 
-            return new AddressParseResult(extracted);
+            return new AddressParseResult(extracted, match);
         }
 
         /// <summary>

--- a/src/AddressParser/AddressParser.csproj
+++ b/src/AddressParser/AddressParser.csproj
@@ -17,7 +17,7 @@
     <RepositoryUrl>https://github.com/jamesrcounts/usaddress</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">


### PR DESCRIPTION
Add RegularExpressions.Match object to the AddressParseResult. The goal is to provide positional information in input text to external consumers.